### PR TITLE
adapt to 2018.1.x gluon master

### DIFF
--- a/ddhcpd/Makefile
+++ b/ddhcpd/Makefile
@@ -14,7 +14,7 @@ PKG_INSTALL:=1
 
 TARGET_CFLAGS += -DLOG_LEVEL=20 
 
-include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/../package/gluon.mk
 
 define Package/ddhcpd
   SECTION:=net


### PR DESCRIPTION
This has to merge into a new branch, we need two different branches, one for 2017.1.x and one for 2018