### PR TITLE
Retrieve IPv4 address of gateway via respondd

### DIFF
--- a/ddhcpd/Makefile
+++ b/ddhcpd/Makefile
@@ -2,6 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddhcpd
 PKG_VERSION:=2018-06-28
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/sargon/ddhcpd

--- a/ddhcpd/files/usr/sbin/ddhcpd-gateway-update
+++ b/ddhcpd/files/usr/sbin/ddhcpd-gateway-update
@@ -1,15 +1,85 @@
 #!/bin/sh
 
-GW="$(batctl gwl | grep '=>' | cut -f 2 -d ' ')"
-GW_MAC="$(batctl tg | grep "$GW" | cut -d ' ' -f 3)"
+CACHE_TTL=600
+CACHE_FILE=/tmp/ddhcp_gw_cache
 
-COUNT=0
-for gw_mac in "$GW_MAC" ; do
-  GW_ADDR=$(batctl dc | grep "$gw_mac" | sed -e 's/^[^0-9]*\([0-9]\+\)/\1/' | cut -d ' ' -f 1)
-  COUNT=$(expr $COUNT + 1)
+GW_UPDATE_TRIES=5
+
+
+verbose() {
+	[ -n "$VERBOSE" ] && ( >&2 echo $@ )
+}
+
+mac_to_ipv6_ll() {
+	IFS=':'; set $1; unset IFS
+	echo "fe80::$(printf %02x $((0x$1 ^ 2)))$2:${3}ff:fe$4:$5$6"
+}
+
+get_gw_ipv4_address() {
+	local gwmac="$1"
+	local gwid="`echo "$gwmac" | tr -d ':'`"
+	gluon-neighbour-info -p 1001 -d "`mac_to_ipv6_ll "$gwmac"`" -i br-client -r gateway | \
+		while read resp; do
+			local node_id="`echo "$resp" | jsonfilter -e '$.node_id'`"
+			if [ "$node_id" = "$gwid" ]; then
+				echo "$resp" | jsonfilter -e '$.address.ipv4'
+			fi
+		done
+}
+
+gateway_lost() {
+	verbose Gateway lost, removing dhcp options
+	rm -f "$CACHE_FILE"
+	/usr/sbin/ddhcpdctl -r 3
+	/usr/sbin/ddhcpdctl -r 6
+}
+
+update_gateway() {
+	verbose Updating dhcp options
+	/usr/sbin/ddhcpdctl -o "3:4:$1"
+	/usr/sbin/ddhcpdctl -o "6:4:$1"
+}
+
+gwmac="`batctl gwl | grep '=>' | cut -d' ' -f2`"
+[ -z "$gwmac" ] && {
+	verbose Failed to determine mac address of current gateway
+	gateway_lost
+	exit 1
+}
+
+verbose Got gateway mac address: "$gwmac"
+
+[ -f "$CACHE_FILE" ] && {
+	verbose Retrieving cache
+	source "$CACHE_FILE"
+	now="`date +'%s'`"
+	if echo "$last_update_time" | egrep -q '^[0-9]+$' && \
+	    echo "$last_gwaddr" | egrep -q '^(([0-9]){1,3}\.){3}[0-9]{1,3}$'; then
+		verbose Gateway mac address cache found, age $(($now - $last_update_time))
+		if [ "$gwmac" = "$last_gwmac" ] && \
+		    [ $(($now - $last_update_time)) -lt "$CACHE_TTL" ]; then
+			verbose Cache is up to date
+			update_gateway "$last_gwaddr"
+			exit 0
+		fi
+	fi
+	verbose Updating cache
+}
+
+for _ in seq "$GW_UPDATE_TRIES"; do
+	gwaddr="`get_gw_ipv4_address "$gwmac"`"
+	[ -n "$gwaddr" ] && break
 done
+[ -z "$gwaddr" ] && {
+	verbose Failed to retrieve gateway IPv4 address
+	gateway_lost
+	exit 2
+}
 
-[[ "$COUNT" -eq 1 ]] || exit 1
+verbose Got gateway IPv4 address: "$gwaddr"
 
-/usr/sbin/ddhcpdctl -o "3:4:${GW_ADDR}"
-/usr/sbin/ddhcpdctl -o "6:4:${GW_ADDR}"
+echo "last_gwmac=\"$gwmac\"" > "$CACHE_FILE"
+echo "last_gwaddr=\"$gwaddr\"" >> "$CACHE_FILE"
+echo "last_update_time=`date +'%s'`" >> "$CACHE_FILE"
+
+update_gateway "$gwaddr"


### PR DESCRIPTION
The DAT is not suitable for determining the IPv4 mesh address in all
situations. Thus ddhcpd now relies on the respondd protocol to retrieve
the IPv4 address of the gateway.

The corresponding respondd service is implemented in [mesh-announce](https://github.com/ffnord/mesh-announce) [PR #33](https://github.com/ffnord/mesh-announce/pull/33)

There is still some potential for optimization in this PR though. Currently the respondd request is sent to `ff02::1`. Since we do know the gateways mac address we could however request it via the link-local of the gw.

Also I don't think that starting and stopping ddhcpd is a good idea. We should probably implement some kind of "passive" mode that can be triggered via ddhcpdctl where ddhcpd does not issue any new leases but still keeps track of block usage, released leases and such.