### PR TITLE
roamguide: rm -rf in case the lock file is a folder

### DIFF
--- a/roamguide/files/usr/bin/roamguide
+++ b/roamguide/files/usr/bin/roamguide
@@ -19,7 +19,7 @@ try_lock(){
   fi
   rm -rf "$LOCK"
   echo "$$" > "$LOCK"
-  trap "rm $LOCK" EXIT
+  trap "rm -rf $LOCK" EXIT
 }
 
 wifi_kick(){


### PR DESCRIPTION
This should be added for legacy compatibility