### PR TITLE
ddhcpd: Parse output of batctl openwrt-2018.1-1 correctly

### DIFF
--- a/ddhcpd/Makefile
+++ b/ddhcpd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddhcpd
 PKG_VERSION:=2019-01-07
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/sargon/ddhcpd

--- a/ddhcpd/files/usr/sbin/ddhcpd-gateway-update
+++ b/ddhcpd/files/usr/sbin/ddhcpd-gateway-update
@@ -40,7 +40,7 @@ update_gateway() {
 	/usr/sbin/ddhcpdctl -o "6:4:$1"
 }
 
-gwmac="`batctl gwl | grep '=>' | cut -d' ' -f2`"
+gwmac="`batctl gwl | sed 's/([[:space:]]*[0-9]\+)//g' | sed 's/[[:space:]]\+/ /g' | egrep '(^\*)|(=>)' | cut -d' ' -f2`"
 [ -z "$gwmac" ] && {
 	verbose Failed to determine mac address of current gateway
 	gateway_lost


### PR DESCRIPTION
The current gateway identifier on 2013.4 '=>' has been replaced by '*' in
newer versions of batctl