### PR TITLE
ddhcpd: Remove 'enabled' key from default config

### DIFF
--- a/ddhcpd/files/etc/config/ddhcpd
+++ b/ddhcpd/files/etc/config/ddhcpd
@@ -1,5 +1,4 @@
 config ddhcpd 'settings'
-     option enabled '1'
      option dhcp_interface 'local-node'
      option server_interface 'br-client'
      option block_size_pow '2'


### PR DESCRIPTION
Having a default setting for enabled breaks ddhcpd configuration from the site config