### PR TITLE
ddhcpd: Remove dysfunctional arp-ping hook

### DIFF
--- a/ddhcpd/files/etc/ddhcpd.d/000-arp-ping
+++ b/ddhcpd/files/etc/ddhcpd.d/000-arp-ping
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-case "$1" in
-  (lease):
-    ping -c 1 -w 1 -I 10.116.254.254 "$2"
-  break;
-esac


### PR DESCRIPTION
Didn't work and had hardcoded IPv4 address