### PR TITLE
fix lua error: (E011) invalid escape sequence '\.'

### DIFF
--- a/ddhcpd/luasrc/lib/gluon/upgrade/400-ddhcpd-firewall
+++ b/ddhcpd/luasrc/lib/gluon/upgrade/400-ddhcpd-firewall
@@ -1,27 +1,27 @@
 #!/usr/bin/lua
 local e=require('simple-uci').cursor()
 e:section('firewall','rule','mesh_ddhcpd',{
-name='mesh_ddhcpd',
-src='mesh',
-family='ipv6',
-dest_port='1234',
-proto='udp',
-target='ACCEPT',
+  name='mesh_ddhcpd',
+  src='mesh',
+  family='ipv6',
+  dest_port='1234',
+  proto='udp',
+  target='ACCEPT',
 })
 e:section('firewall','rule','mesh_d2d',{
-name='mesh_d2d',
-src='mesh',
-family='ipv6',
-dest_port='1235',
-proto='udp',
-target='ACCEPT',
+  name='mesh_d2d',
+  src='mesh',
+  family='ipv6',
+  dest_port='1235',
+  proto='udp',
+  target='ACCEPT',
 })
 e:section('firewall','rule','client_dhcp',{
-name='client_dhcp',
-src='local_client',
-family='ipv4',
-dest_port='67',
-proto='udp',
-target='ACCEPT',
+  name='client_dhcp',
+  src='local_client',
+  family='ipv4',
+  dest_port='67',
+  proto='udp',
+  target='ACCEPT',
 })
 e:save('firewall')

--- a/ddhcpd/luasrc/lib/gluon/upgrade/500-ddhcpd
+++ b/ddhcpd/luasrc/lib/gluon/upgrade/500-ddhcpd
@@ -19,7 +19,7 @@ if site.ddhcpd then
     payload=site.next_node.ip4()
   })
   uci:delete('ddhcpd','broadcast')
-  cidr=tonumber(string.gsub(site:prefix4(),"[%w\.]+/(%d+)","%1"),10)
+  cidr=tonumber(string.gsub(site:prefix4(),"[%w.]+/(%d+)","%1"),10)
   netmask=''
   for i=1,3 do
     netmask=netmask..tostring(256-2^math.max(0,8-cidr))..'.'


### PR DESCRIPTION
This will solve an error that is detected by the new gluon luacheck linter and lua files are renamed to `.lua` (as the new gluon standard)