### PR TITLE
prevent error in log: /etc/ddhcpd.hook: line 6: /etc/ddhcpd.d/*: not found

### DIFF
--- a/ddhcpd/files/etc/ddhcpd.hook
+++ b/ddhcpd/files/etc/ddhcpd.hook
@@ -2,6 +2,7 @@
 
 for i in /etc/ddhcpd.d/*
 do
-  $i "$@"
+  if [ -e "$i" ] ; then
+    $i "$@"
+  fi
 done
-

--- a/ddhcpd/files/etc/ddhcpd.hook
+++ b/ddhcpd/files/etc/ddhcpd.hook
@@ -3,6 +3,6 @@
 for i in /etc/ddhcpd.d/*
 do
   if [ -e "$i" ] ; then
-    $i "$@"
+    "$i" "$@"
   fi
 done


### PR DESCRIPTION
without this, this message appears every call in the output of `logread`